### PR TITLE
Rrmartins i18n

### DIFF
--- a/config_en.toml
+++ b/config_en.toml
@@ -1,4 +1,4 @@
-baseurl = "http://gopherconbr.org"
+baseurl = "http://gopherconbr.org/en"
 languageCode = "en-us"
 title = "GopherConBR 2016"
 contentdir = "content/en"

--- a/data/translations/en-US.yaml
+++ b/data/translations/en-US.yaml
@@ -27,4 +27,4 @@ character_copyright: Gopher character is based on a sketch
 license: under license
 aerial_images: Aerial Images made by
 coc: Code of Conduct
-coclink: "/conduct"
+coclink: "/en/conduct"


### PR DESCRIPTION
@guilhermebr fizemos o paranaue do `/` e do `/en/`, precisamos alterar o _caddy_ para rodar:

```
hugo -t=gopherconbr --config=config.toml
hugo -t=gopherconbr --config=config_en.toml
```

Acredito que na linha 12 do Caddyfile, podemos alterar para ficar assim:

```
then hugo -t gopherconbr --destination=/site-source/gopherconbr/public  --config=config.toml
then hugo -t gopherconbr --destination=/site-source/gopherconbr/public/en  --config=config_en.toml
```

analise e mudanças feitas pareando com o @felipeweb 