### PR TITLE
decreasing margin-top size in the navbar

### DIFF
--- a/themes/gopherconbr/layouts/_default/single.html
+++ b/themes/gopherconbr/layouts/_default/single.html
@@ -6,7 +6,7 @@
   <!-- Fixed navbar -->
   {{ partial "navbar_single.html" . }}
 
-  <section class="highlight" style="margin-top: 6%">
+  <section class="highlight" style="margin-top: 5%">
 
     <div class="container">
       <h1>{{ .Title }}</h1>


### PR DESCRIPTION
Quando abri a tela do codigo de conduta, vi que tinha uma barrinha em baixo do navbar.

![screen shot 2016-07-26 at 07 33 05](https://cloud.githubusercontent.com/assets/455676/17134963/8d162256-5303-11e6-8505-322d9527ae48.png)

ficou assim:
![screen shot 2016-07-26 at 07 33 24](https://cloud.githubusercontent.com/assets/455676/17134979/aa943016-5303-11e6-8f5b-8189164e8d8a.png)
